### PR TITLE
more improvements

### DIFF
--- a/Application/Dopamine/Jailbreak/DOJailbreaker.m
+++ b/Application/Dopamine/Jailbreak/DOJailbreaker.m
@@ -524,6 +524,10 @@ int ensure_randomized_cdhash(const char* inputPath, void* cdhashOut);
 
 - (void)runWithError:(NSError **)errOut didRemoveJailbreak:(BOOL*)didRemove showLogs:(BOOL *)showLogs
 {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
+    });
+    
     BOOL removeJailbreakEnabled = [[DOPreferenceManager sharedManager] boolPreferenceValueForKey:@"removeJailbreakEnabled" fallback:NO];
     BOOL tweaksEnabled = [[DOPreferenceManager sharedManager] boolPreferenceValueForKey:@"tweakInjectionEnabled" fallback:YES];
     BOOL idownloadEnabled = [[DOPreferenceManager sharedManager] boolPreferenceValueForKey:@"idownloadEnabled" fallback:NO];
@@ -590,6 +594,8 @@ int ensure_randomized_cdhash(const char* inputPath, void* cdhashOut);
     *errOut = [self injectLaunchdHook];
     if (*errOut) return;
     
+    // don't load tweak during jailbreaking
+    setenv("DISABLE_TWEAKS", "1", 1);
     // using the stock path during jailbreaking
     setenv("DYLD_INSERT_LIBRARIES", JBROOT_PATH("/basebin/systemhook.dylib"), 1);
     

--- a/BaseBin/launchdhook/src/crashreporter.m
+++ b/BaseBin/launchdhook/src/crashreporter.m
@@ -15,7 +15,6 @@
 #include <mach-o/dyld.h>
 extern CFStringRef CFCopySystemVersionString(void);
 
-void abort_with_reason(uint32_t reason_namespace, uint64_t reason_code, const char *reason_string, uint64_t reason_flags);
 #define RB_QUICK	0x400
 #define RB_PANIC	0x800
 int reboot_np(int howto, const char *message);
@@ -506,12 +505,12 @@ int sigcatch[] = {
 
 void crashreporter_start(void)
 {
-	// for(int i=0; i<sizeof(sigcatch)/sizeof(sigcatch[0]); i++) {
-	// 	struct sigaction act = {0};
-	// 	act.sa_flags = SA_SIGINFO|SA_RESETHAND;
-	// 	act.sa_sigaction = signal_handler;
-	// 	sigaction(sigcatch[i], &act, NULL);
-	// }
+	for(int i=0; i<sizeof(sigcatch)/sizeof(sigcatch[0]); i++) {
+		struct sigaction act = {0};
+		act.sa_flags = SA_SIGINFO|SA_RESETHAND;
+		act.sa_sigaction = signal_handler;
+		sigaction(sigcatch[i], &act, NULL);
+	}
 
 	if (gCrashReporterState == kCrashReporterStateNotActive) {
 		mach_port_allocate(mach_task_self_, MACH_PORT_RIGHT_RECEIVE, &gExceptionPort);

--- a/BaseBin/launchdhook/src/main.m
+++ b/BaseBin/launchdhook/src/main.m
@@ -24,7 +24,6 @@ char HOOK_DYLIB_PATH[PATH_MAX] = {0};
 
 bool gInEarlyBoot = true;
 
-void abort_with_reason(uint32_t reason_namespace, uint64_t reason_code, const char *reason_string, uint64_t reason_flags);
 #define RB_QUICK	0x400
 #define RB_PANIC	0x800
 int reboot_np(int howto, const char *message);

--- a/BaseBin/launchdhook/src/update.m
+++ b/BaseBin/launchdhook/src/update.m
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-void abort_with_reason(uint32_t reason_namespace, uint64_t reason_code, const char *reason_string, uint64_t reason_flags);
 #define RB_QUICK	0x400
 #define RB_PANIC	0x800
 int reboot_np(int howto, const char *message);

--- a/BaseBin/roothidehooks/cfprefsd.x
+++ b/BaseBin/roothidehooks/cfprefsd.x
@@ -12,6 +12,13 @@ BOOL preferencePlistNeedsRedirection(NSString *plistPath)
 
 	NSString *plistName = plistPath.lastPathComponent;
 
+	NSArray* appleInternalBundleIds = @[
+		@"com.apple.Terminal.plist",
+	];
+
+	if ([appleInternalBundleIds containsObject:plistName])
+		return YES;
+
 	if ([plistName hasPrefix:@"com.apple."]
 	  || [plistName hasPrefix:@"group.com.apple."]
 	 || [plistName hasPrefix:@"systemgroup.com.apple."])

--- a/BaseBin/roothidehooks/main.x
+++ b/BaseBin/roothidehooks/main.x
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <mach-o/dyld.h>
 
+#ifndef DEBUG
+#define NSLog(args...)	
+#endif
+
 NSString* safe_getExecutablePath()
 {
 	char executablePathC[PATH_MAX];

--- a/BaseBin/roothidehooks/pathhook.x
+++ b/BaseBin/roothidehooks/pathhook.x
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+#import <substrate.h>
+#include <roothide.h>
+
+#ifndef DEBUG
+#define NSLog(args...)	
+#endif
+
+CFURLRef (*orig__CFCopyHomeDirURLForUser)(const char *username, bool fallBackToHome) = NULL;
+CFURLRef new__CFCopyHomeDirURLForUser(const char *username, bool fallBackToHome)
+{
+	CFURLRef url = orig__CFCopyHomeDirURLForUser(username, fallBackToHome);
+
+	char path[PATH_MAX]={0};
+	if(CFURLGetFileSystemRepresentation(url, 0, (UInt8*)path, sizeof(path)))
+	{
+		const char* jbpath = rootfs(path);
+		if(strncmp(jbpath, "/rootfs/", sizeof("/rootfs/")-1) == 0)
+		{
+			CFRelease(url);
+
+			const char* newpath = jbroot(path);
+			url = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8*)newpath, strlen(newpath), true);
+		}
+	}
+
+	return url;
+}
+
+__attribute__((visibility("default"))) void pathhook()
+{
+    NSLog(@"pathhook..");
+
+	MSImageRef coreFoundationImage = MSGetImageByName("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation");
+	void* _CFCopyHomeDirURLForUser_ptr = MSFindSymbol(coreFoundationImage, "__CFCopyHomeDirURLForUser");
+	if(_CFCopyHomeDirURLForUser_ptr)
+	{
+		MSHookFunction(_CFCopyHomeDirURLForUser_ptr, (void *)&new__CFCopyHomeDirURLForUser, (void **)&orig__CFCopyHomeDirURLForUser);
+		NSLog(@"hook __CFCopyHomeDirURLForUser %p => %p : %p", _CFCopyHomeDirURLForUser_ptr, new__CFCopyHomeDirURLForUser, orig__CFCopyHomeDirURLForUser);
+	}
+}


### PR DESCRIPTION
1: redirect the home directory of the jailbreak root process
2: fix potential updatelinks failure during jailbreaking
3: add signal capture to launchd's crashreporter
4: prevent screen from going to sleep during jailbreaking
5: redirect preference paths for some apple internal apps